### PR TITLE
Increase max message size to 3MB for producer and consumer

### DIFF
--- a/src/main/java/no/novari/kafka/KafkaConfiguration.java
+++ b/src/main/java/no/novari/kafka/KafkaConfiguration.java
@@ -81,6 +81,8 @@ public class KafkaConfiguration {
         props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getConsumer().getGroupId());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, 3145728);
+        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 3145728);
         props.putAll(securityProps);
         return new ConsumerConfig(props);
     }
@@ -92,6 +94,7 @@ public class KafkaConfiguration {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, List.of(OriginHeaderProducerInterceptor.class));
+        props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 3145728);
         props.put(OriginHeaderProducerInterceptor.ORIGIN_APPLICATION_ID_PRODUCER_CONFIG, kafkaConfigurationProperties.getApplicationId());
         props.putAll(securityProps);
         return new ProducerConfig(props);


### PR DESCRIPTION
## Summary

- Setter `MAX_REQUEST_SIZE_CONFIG` til 3MB på producer
- Setter `FETCH_MAX_BYTES_CONFIG` og `MAX_PARTITION_FETCH_BYTES_CONFIG` til 3MB på consumer
- Grensen er hardkodet i biblioteket og ikke konfigurerbar per applikasjon — broker (Aiven) er den øvre skranken med 5MB