### PR TITLE
FFS-2221 Aktiver trace-propagering i fint-kafka

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,20 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "24 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Java/Kotlin
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-codeql.yaml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ README-en er skrevet for:
 12. [Request/Reply](#requestreply)
 13. [Topic-oppretting og cleanup policies](#topic-oppretting-og-cleanup-policies)
 14. [Helseovervåking (liveness/readiness)](#helseovervåking-livenessreadiness)
-15. [Best practices](#best-practices)
-16. [Feilsøking](#feilsøking)
-17. [API-hurtigreferanse](#api-hurtigreferanse)
-18. [Oppgraderingsguider (major-versjoner)](docs/upgrading/README.md)
+15. [Sporing (distribuert tracing)](#sporing-distribuert-tracing)
+16. [Best practices](#best-practices)
+17. [Feilsøking](#feilsøking)
+18. [API-hurtigreferanse](#api-hurtigreferanse)
+19. [Oppgraderingsguider (major-versjoner)](docs/upgrading/README.md)
 
 ## Kom i gang
 
@@ -82,6 +83,7 @@ Viktige nøkler:
 - `novari.kafka.default-replicas` brukes ved topic-oppretting (hvis ikke satt, er bibliotekets default `2`)
 - `novari.kafka.topic.org-id` + `novari.kafka.topic.domain-context` er defaults i topic-navn
 - `fint.kafka.enable-ssl=true` aktiverer SSL-props basert på `spring.kafka.ssl.*`
+- `fint.kafka.tracing.enabled=true` aktiverer distribuert sporing, se [Sporing (distribuert tracing)](#sporing-distribuert-tracing)
 - consumer default `auto.offset.reset` settes til `earliest` i bibliotekets `ConsumerConfig`-bean
 
 ## Arkitektur
@@ -1138,6 +1140,31 @@ fint:
 ```
 
 En app som eksponerer et HTTP-API og ikke ønsker at Kafka-nedetid skal trekke poden ut av trafikk, kan holde `kafkaConnectivityHealthIndicator` utenfor readiness ved selv å sette `management.endpoint.health.group.readiness.include` (bibliotekets default settes kun når appen ikke selv har satt property-en).
+
+## Sporing (distribuert tracing)
+
+Biblioteket kan propagere W3C trace-kontekst (`traceparent`) gjennom Kafka-meldinger, slik at producer- og consumer-spenn - og hele request/reply-kjeden - havner i samme spor i sporingsverktøyet. Dette bygger på Spring Kafkas egen observasjonsstøtte (`KafkaTemplate`/`ReplyingKafkaTemplate`/lytter-containerne), ikke egen instrumenteringskode i dette biblioteket.
+
+### Mekanisme
+
+`ObservationRegistry` hentes via `ObjectProvider`, siden `KafkaTemplate`- og lytter-container-instansene bygges programmatisk av bibliotekets fabrikker og ikke er Spring-beans i seg selv. Er sporing aktivert, settes registeret eksplisitt på hver produsent- og konsument-instans som opprettes.
+
+### Aktivering
+
+**Av som standard.** Mange applikasjoner har allerede et `ObservationRegistry`-bean i konteksten (via `spring-boot-starter-actuator` + `micrometer-tracing`) uten å ha bedt om Kafka-sporing spesifikt - biblioteket skal derfor ikke endre oppførsel for eksisterende brukere ved en versjonsoppgradering. Sporing må slås på eksplisitt:
+
+```yaml
+fint:
+  kafka:
+    tracing:
+      enabled: true
+```
+
+I tillegg må et `ObservationRegistry`-bean faktisk finnes i konteksten (typisk via `micrometer-tracing-bridge-otel`) - uten det gjør bryteren ingenting.
+
+### Begrensning: batch-lyttere
+
+Batch-lyttere (`createBatchListenerContainerFactory`) gir aldri consumer-spenn, uavhengig av denne bryteren - dette er en begrensning i Spring Kafkas egen observasjonsstøtte, ikke noe dette biblioteket kan løse. Produsentsiden instrumenteres som normalt.
 
 ## Best practices
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ novari:
     topic:
       org-id: my-org
       domain-context: my-domain
+    tracing:
+      enabled: true
 
 fint:
   kafka:
@@ -82,8 +84,8 @@ Viktige nøkler:
 - `novari.kafka.application-id` brukes i producer-header `origin.application.id`
 - `novari.kafka.default-replicas` brukes ved topic-oppretting (hvis ikke satt, er bibliotekets default `2`)
 - `novari.kafka.topic.org-id` + `novari.kafka.topic.domain-context` er defaults i topic-navn
-- `fint.kafka.enable-ssl=true` aktiverer SSL-props basert på `spring.kafka.ssl.*`
-- `fint.kafka.tracing.enabled=true` aktiverer distribuert sporing, se [Sporing (distribuert tracing)](#sporing-distribuert-tracing)
+- `novari.kafka.tracing.enabled=true` aktiverer distribuert sporing, se [Sporing (distribuert tracing)](#sporing-distribuert-tracing)
+- `fint.kafka.enable-ssl=true` aktiverer SSL-props basert på `spring.kafka.ssl.*` (legacy navnerom, beholdt for bakoverkompatibilitet)
 - consumer default `auto.offset.reset` settes til `earliest` i bibliotekets `ConsumerConfig`-bean
 
 ## Arkitektur
@@ -1151,16 +1153,18 @@ Biblioteket kan propagere W3C trace-kontekst (`traceparent`) gjennom Kafka-meldi
 
 ### Aktivering
 
-**Av som standard.** Mange applikasjoner har allerede et `ObservationRegistry`-bean i konteksten (via `spring-boot-starter-actuator` + `micrometer-tracing`) uten å ha bedt om Kafka-sporing spesifikt - biblioteket skal derfor ikke endre oppførsel for eksisterende brukere ved en versjonsoppgradering. Sporing må slås på eksplisitt:
+**Av som standard i biblioteket.** Mange applikasjoner har allerede et `ObservationRegistry`-bean i konteksten (via `spring-boot-starter-actuator` + `micrometer-tracing`) uten å ha bedt om Kafka-sporing spesifikt - biblioteket selv skal derfor ikke endre oppførsel for eksisterende brukere ved en versjonsoppgradering. Sporing må slås på eksplisitt per applikasjon:
 
 ```yaml
-fint:
+novari:
   kafka:
     tracing:
       enabled: true
 ```
 
 I tillegg må et `ObservationRegistry`-bean faktisk finnes i konteksten (typisk via `micrometer-tracing-bridge-otel`) - uten det gjør bryteren ingenting.
+
+Nye applikasjoner bør sette denne til `true` fra start. Planen er etter hvert å fjerne bryteren og alltid ha sporing på - av-som-standard er et biblioteksvalg for å ikke endre oppførsel bak ryggen på eksisterende brukere ved oppgradering, ikke en anbefaling om å la sporing stå av.
 
 ### Begrensning: batch-lyttere
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.2.3")
+    testImplementation("io.micrometer:micrometer-tracing-bridge-otel")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 
     testFixturesCompileOnly("org.projectlombok:lombok")
     testFixturesAnnotationProcessor("org.projectlombok:lombok")

--- a/src/main/java/no/novari/kafka/consuming/ListenerContainerFactoryService.java
+++ b/src/main/java/no/novari/kafka/consuming/ListenerContainerFactoryService.java
@@ -25,7 +25,7 @@ public class ListenerContainerFactoryService {
     ListenerContainerFactoryService(
         ConsumerFactoryService consumerFactoryService,
         ObjectProvider<ObservationRegistry> observationRegistry,
-        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
+        @Value("${novari.kafka.tracing.enabled:false}") boolean tracingEnabled
     ) {
         this.consumerFactoryService = consumerFactoryService;
         this.observationRegistry = observationRegistry;

--- a/src/main/java/no/novari/kafka/consuming/ListenerContainerFactoryService.java
+++ b/src/main/java/no/novari/kafka/consuming/ListenerContainerFactoryService.java
@@ -1,7 +1,10 @@
 package no.novari.kafka.consuming;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.CommonErrorHandler;
@@ -16,23 +19,31 @@ import java.util.function.Function;
 public class ListenerContainerFactoryService {
 
     private final ConsumerFactoryService consumerFactoryService;
+    private final ObjectProvider<ObservationRegistry> observationRegistry;
+    private final boolean tracingEnabled;
 
-    ListenerContainerFactoryService(ConsumerFactoryService consumerFactoryService) {
+    ListenerContainerFactoryService(
+        ConsumerFactoryService consumerFactoryService,
+        ObjectProvider<ObservationRegistry> observationRegistry,
+        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
+    ) {
         this.consumerFactoryService = consumerFactoryService;
+        this.observationRegistry = observationRegistry;
+        this.tracingEnabled = tracingEnabled;
     }
 
     public <VALUE> ConcurrentKafkaListenerContainerFactory<String, VALUE> createRecordListenerContainerFactory(
-            Class<VALUE> valueClass,
-            Consumer<ConsumerRecord<String, VALUE>> recordProcessor,
-            ListenerConfiguration listenerConfiguration,
-            CommonErrorHandler errorHandler
+        Class<VALUE> valueClass,
+        Consumer<ConsumerRecord<String, VALUE>> recordProcessor,
+        ListenerConfiguration listenerConfiguration,
+        CommonErrorHandler errorHandler
     ) {
         return createRecordListenerContainerFactory(
-                valueClass,
-                recordProcessor,
-                listenerConfiguration,
-                errorHandler,
-                null
+            valueClass,
+            recordProcessor,
+            listenerConfiguration,
+            errorHandler,
+            null
         );
     }
 
@@ -41,42 +52,42 @@ public class ListenerContainerFactoryService {
      * Use {@code containerCustomizer} for options such as {@code container.setConcurrency(n)}.
      */
     public <VALUE> ConcurrentKafkaListenerContainerFactory<String, VALUE> createRecordListenerContainerFactory(
-            Class<VALUE> valueClass,
-            Consumer<ConsumerRecord<String, VALUE>> recordProcessor,
-            ListenerConfiguration listenerConfiguration,
-            CommonErrorHandler errorHandler,
-            Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
+        Class<VALUE> valueClass,
+        Consumer<ConsumerRecord<String, VALUE>> recordProcessor,
+        ListenerConfiguration listenerConfiguration,
+        CommonErrorHandler errorHandler,
+        Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
     ) {
         return createListenerContainerFactory(
-                valueClass,
-                listenerConfiguration,
-                errorHandler,
-                container ->
-                        new OffsetSeekingRecordListener<>(
-                                recordProcessor,
-                                listenerConfiguration
-                                        .getOnPartitionsAssigned()
-                                        .orElse(null),
-                                listenerConfiguration
-                                        .getOnPartitionsRevoked()
-                                        .orElse(null)
-                        ),
-                containerCustomizer
+            valueClass,
+            listenerConfiguration,
+            errorHandler,
+            _ ->
+                new OffsetSeekingRecordListener<>(
+                    recordProcessor,
+                    listenerConfiguration
+                        .getOnPartitionsAssigned()
+                        .orElse(null),
+                    listenerConfiguration
+                        .getOnPartitionsRevoked()
+                        .orElse(null)
+                ),
+            containerCustomizer
         );
     }
 
     public <VALUE> ConcurrentKafkaListenerContainerFactory<String, VALUE> createBatchListenerContainerFactory(
-            Class<VALUE> valueClass,
-            Consumer<List<ConsumerRecord<String, VALUE>>> batchProcessor,
-            ListenerConfiguration listenerConfiguration,
-            CommonErrorHandler errorHandler
+        Class<VALUE> valueClass,
+        Consumer<List<ConsumerRecord<String, VALUE>>> batchProcessor,
+        ListenerConfiguration listenerConfiguration,
+        CommonErrorHandler errorHandler
     ) {
         return createBatchListenerContainerFactory(
-                valueClass,
-                batchProcessor,
-                listenerConfiguration,
-                errorHandler,
-                null
+            valueClass,
+            batchProcessor,
+            listenerConfiguration,
+            errorHandler,
+            null
         );
     }
 
@@ -85,84 +96,90 @@ public class ListenerContainerFactoryService {
      * Use {@code containerCustomizer} for options such as {@code container.setConcurrency(n)}.
      */
     public <VALUE> ConcurrentKafkaListenerContainerFactory<String, VALUE> createBatchListenerContainerFactory(
-            Class<VALUE> valueClass,
-            Consumer<List<ConsumerRecord<String, VALUE>>> batchProcessor,
-            ListenerConfiguration listenerConfiguration,
-            CommonErrorHandler errorHandler,
-            Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
+        Class<VALUE> valueClass,
+        Consumer<List<ConsumerRecord<String, VALUE>>> batchProcessor,
+        ListenerConfiguration listenerConfiguration,
+        CommonErrorHandler errorHandler,
+        Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
     ) {
         return createListenerContainerFactory(
-                valueClass,
-                listenerConfiguration,
-                errorHandler,
-                container ->
-                        new OffsetSeekingBatchListener<>(
-                                batchProcessor,
-                                listenerConfiguration
-                                        .getOnPartitionsAssigned()
-                                        .orElse(null),
-                                listenerConfiguration
-                                        .getOnPartitionsRevoked()
-                                        .orElse(null)
-                        ),
-                containerCustomizer
+            valueClass,
+            listenerConfiguration,
+            errorHandler,
+            _ ->
+                new OffsetSeekingBatchListener<>(
+                    batchProcessor,
+                    listenerConfiguration
+                        .getOnPartitionsAssigned()
+                        .orElse(null),
+                    listenerConfiguration
+                        .getOnPartitionsRevoked()
+                        .orElse(null)
+                ),
+            containerCustomizer
         );
     }
 
     public <VALUE> ConcurrentKafkaListenerContainerFactory<String, VALUE> createListenerContainerFactory(
-            Class<VALUE> valueClass,
-            ListenerConfiguration listenerConfiguration,
-            CommonErrorHandler errorHandler,
-            Function<ConcurrentMessageListenerContainer<String, VALUE>, OffsetSeekingListener> messageListenerCreator,
-            Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
+        Class<VALUE> valueClass,
+        ListenerConfiguration listenerConfiguration,
+        CommonErrorHandler errorHandler,
+        Function<ConcurrentMessageListenerContainer<String, VALUE>, OffsetSeekingListener> messageListenerCreator,
+        Consumer<ConcurrentMessageListenerContainer<String, VALUE>> containerCustomizer
     ) {
         ConcurrentKafkaListenerContainerFactory<String, VALUE> concurrentKafkaListenerContainerFactory =
-                new ConcurrentKafkaListenerContainerFactory<>();
+            new ConcurrentKafkaListenerContainerFactory<>();
 
         ConsumerFactory<String, VALUE> consumerFactory = consumerFactoryService.createFactory(
-                valueClass,
-                listenerConfiguration
+            valueClass,
+            listenerConfiguration
         );
         concurrentKafkaListenerContainerFactory.setConsumerFactory(consumerFactory);
 
         concurrentKafkaListenerContainerFactory.setContainerCustomizer(container -> {
 
             listenerConfiguration
-                    .getMaxPollRecords()
-                    .ifPresent(
-                            maxPollRecords ->
-                                    container
-                                            .getContainerProperties()
-                                            .getKafkaConsumerProperties()
-                                            .setProperty(
-                                                    ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
-                                                    String.valueOf(maxPollRecords)
-                                            )
-                    );
+                .getMaxPollRecords()
+                .ifPresent(
+                    maxPollRecords ->
+                        container
+                            .getContainerProperties()
+                            .getKafkaConsumerProperties()
+                            .setProperty(
+                                ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+                                String.valueOf(maxPollRecords)
+                            )
+                );
 
             listenerConfiguration
-                    .getMaxPollInterval()
-                    .ifPresent(
-                            maxPollInterval -> container
-                                    .getContainerProperties()
-                                    .getKafkaConsumerProperties()
-                                    .setProperty(
-                                            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
-                                            String.valueOf(maxPollInterval.toMillis())
-                                    )
-                    );
+                .getMaxPollInterval()
+                .ifPresent(
+                    maxPollInterval -> container
+                        .getContainerProperties()
+                        .getKafkaConsumerProperties()
+                        .setProperty(
+                            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
+                            String.valueOf(maxPollInterval.toMillis())
+                        )
+                );
 
             container.setCommonErrorHandler(errorHandler);
 
+            if (tracingEnabled) {
+                observationRegistry.ifAvailable(registry -> {
+                    container.getContainerProperties().setObservationRegistry(registry);
+                    container.getContainerProperties().setObservationEnabled(true);
+                });
+            }
+
             OffsetSeekingListener messageListener = messageListenerCreator.apply(container);
 
-
             listenerConfiguration
-                    .getOffsetSeekingTrigger()
-                    .ifPresent(
-                            offsetSeekingTrigger ->
-                                    offsetSeekingTrigger.addOffsetResettingMessageListener(messageListener)
-                    );
+                .getOffsetSeekingTrigger()
+                .ifPresent(
+                    offsetSeekingTrigger ->
+                        offsetSeekingTrigger.addOffsetResettingMessageListener(messageListener)
+                );
             container.setupMessageListener(messageListener);
 
             if (containerCustomizer != null) {

--- a/src/main/java/no/novari/kafka/producing/TemplateFactory.java
+++ b/src/main/java/no/novari/kafka/producing/TemplateFactory.java
@@ -20,7 +20,7 @@ public class TemplateFactory {
         ProducerFactory producerFactory,
         ObjectProvider<ProducerFailureTracker> producerFailureTracker,
         ObjectProvider<ObservationRegistry> observationRegistry,
-        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
+        @Value("${novari.kafka.tracing.enabled:false}") boolean tracingEnabled
     ) {
         this.producerFactory = producerFactory;
         this.producerFailureTracker = producerFailureTracker;

--- a/src/main/java/no/novari/kafka/producing/TemplateFactory.java
+++ b/src/main/java/no/novari/kafka/producing/TemplateFactory.java
@@ -1,7 +1,9 @@
 package no.novari.kafka.producing;
 
+import io.micrometer.observation.ObservationRegistry;
 import no.novari.kafka.health.ProducerFailureTracker;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.stereotype.Service;
@@ -11,16 +13,31 @@ public class TemplateFactory {
 
     private final ProducerFactory producerFactory;
     private final ObjectProvider<ProducerFailureTracker> producerFailureTracker;
+    private final ObjectProvider<ObservationRegistry> observationRegistry;
+    private final boolean tracingEnabled;
 
-    TemplateFactory(ProducerFactory producerFactory, ObjectProvider<ProducerFailureTracker> producerFailureTracker) {
+    TemplateFactory(
+        ProducerFactory producerFactory,
+        ObjectProvider<ProducerFailureTracker> producerFailureTracker,
+        ObjectProvider<ObservationRegistry> observationRegistry,
+        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
+    ) {
         this.producerFactory = producerFactory;
         this.producerFailureTracker = producerFailureTracker;
+        this.observationRegistry = observationRegistry;
+        this.tracingEnabled = tracingEnabled;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public <VALUE> KafkaTemplate<String, VALUE> createTemplate(Class<VALUE> valueClass) {
         KafkaTemplate<String, VALUE> kafkaTemplate = new KafkaTemplate<>(producerFactory.createFactory(valueClass));
         producerFailureTracker.ifAvailable(tracker -> kafkaTemplate.setProducerListener((ProducerListener) tracker));
+        if (tracingEnabled) {
+            observationRegistry.ifAvailable(registry -> {
+                kafkaTemplate.setObservationRegistry(registry);
+                kafkaTemplate.setObservationEnabled(true);
+            });
+        }
         return kafkaTemplate;
     }
 

--- a/src/main/java/no/novari/kafka/requestreply/RequestTemplateFactory.java
+++ b/src/main/java/no/novari/kafka/requestreply/RequestTemplateFactory.java
@@ -1,10 +1,13 @@
 package no.novari.kafka.requestreply;
 
+import io.micrometer.observation.ObservationRegistry;
 import no.novari.kafka.consuming.ConsumerFactoryService;
 import no.novari.kafka.consuming.ListenerConfiguration;
 import no.novari.kafka.producing.ProducerFactory;
 import no.novari.kafka.requestreply.topic.name.ReplyTopicNameParameters;
 import no.novari.kafka.topic.name.TopicNameService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
@@ -18,71 +21,84 @@ public class RequestTemplateFactory {
     private final ConsumerFactoryService consumerFactoryService;
     private final ProducerFactory producerFactory;
     private final TopicNameService topicNameService;
+    private final ObjectProvider<ObservationRegistry> observationRegistry;
+    private final boolean tracingEnabled;
 
     RequestTemplateFactory(
-            ProducerFactory producerFactory,
-            ConsumerFactoryService consumerFactoryService,
-            TopicNameService topicNameService
+        ProducerFactory producerFactory,
+        ConsumerFactoryService consumerFactoryService,
+        TopicNameService topicNameService,
+        ObjectProvider<ObservationRegistry> observationRegistry,
+        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
     ) {
         this.producerFactory = producerFactory;
         this.consumerFactoryService = consumerFactoryService;
         this.topicNameService = topicNameService;
+        this.observationRegistry = observationRegistry;
+        this.tracingEnabled = tracingEnabled;
     }
 
     public <REQUEST_VALUE, REPLY_VALUE> RequestTemplate<REQUEST_VALUE, REPLY_VALUE> createTemplate(
-            ReplyTopicNameParameters replyTopicNameParameters,
-            Class<REQUEST_VALUE> requestValueClass,
-            Class<REPLY_VALUE> replyValueClass,
-            Duration replyTimeout,
-            ListenerConfiguration replyListenerConfiguration
+        ReplyTopicNameParameters replyTopicNameParameters,
+        Class<REQUEST_VALUE> requestValueClass,
+        Class<REPLY_VALUE> replyValueClass,
+        Duration replyTimeout,
+        ListenerConfiguration replyListenerConfiguration
     ) {
         ConcurrentMessageListenerContainer<String, REPLY_VALUE> replyListenerContainer =
-                createReplyListenerContainer(
-                        replyTopicNameParameters,
-                        replyValueClass,
-                        replyListenerConfiguration
-                );
+            createReplyListenerContainer(
+                replyTopicNameParameters,
+                replyValueClass,
+                replyListenerConfiguration
+            );
 
         ReplyingKafkaTemplate<String, REQUEST_VALUE, REPLY_VALUE> requestTemplate = createRequestTemplate(
-                requestValueClass,
-                replyListenerContainer
+            requestValueClass,
+            replyListenerContainer
         );
         if (replyTimeout != null) {
             requestTemplate.setDefaultReplyTimeout(replyTimeout);
         }
         return new RequestTemplate<>(
-                requestTemplate,
-                topicNameService
+            requestTemplate,
+            topicNameService
         );
     }
 
     private <REPLY_VALUE> ConcurrentMessageListenerContainer<String, REPLY_VALUE> createReplyListenerContainer(
-            ReplyTopicNameParameters replyTopicNameParameters,
-            Class<REPLY_VALUE> replyValueClass,
-            ListenerConfiguration listenerConfiguration
+        ReplyTopicNameParameters replyTopicNameParameters,
+        Class<REPLY_VALUE> replyValueClass,
+        ListenerConfiguration listenerConfiguration
     ) {
         org.springframework.kafka.core.ConsumerFactory<String, REPLY_VALUE> consumerFactory =
-                consumerFactoryService.createFactory(
-                        replyValueClass,
-                        listenerConfiguration
-                );
+            consumerFactoryService.createFactory(
+                replyValueClass,
+                listenerConfiguration
+            );
         ConcurrentKafkaListenerContainerFactory<String, REPLY_VALUE> listenerFactory =
-                new ConcurrentKafkaListenerContainerFactory<>();
+            new ConcurrentKafkaListenerContainerFactory<>();
         listenerFactory.setConsumerFactory(consumerFactory);
         return listenerFactory.createContainer(topicNameService.validateAndMapToTopicName(replyTopicNameParameters));
     }
 
     private <REQUEST_VALUE, REPLY_VALUE> ReplyingKafkaTemplate<String, REQUEST_VALUE, REPLY_VALUE> createRequestTemplate(
-            Class<REQUEST_VALUE> requestValueClass,
-            ConcurrentMessageListenerContainer<String, REPLY_VALUE> replyListenerContainer
+        Class<REQUEST_VALUE> requestValueClass,
+        ConcurrentMessageListenerContainer<String, REPLY_VALUE> replyListenerContainer
     ) {
         org.springframework.kafka.core.ProducerFactory<String, REQUEST_VALUE> producerFactory =
-                this.producerFactory.createFactory(requestValueClass);
+            this.producerFactory.createFactory(requestValueClass);
 
         ReplyingKafkaTemplate<String, REQUEST_VALUE, REPLY_VALUE> replyingKafkaTemplate = new ReplyingKafkaTemplate<>(
-                producerFactory,
-                replyListenerContainer
+            producerFactory,
+            replyListenerContainer
         );
+        if (tracingEnabled) {
+            // Må settes før start() - endringer etter oppstart blir stille ignorert.
+            observationRegistry.ifAvailable(registry -> {
+                replyingKafkaTemplate.setObservationRegistry(registry);
+                replyingKafkaTemplate.setObservationEnabled(true);
+            });
+        }
         replyingKafkaTemplate.start();
         return replyingKafkaTemplate;
     }

--- a/src/main/java/no/novari/kafka/requestreply/RequestTemplateFactory.java
+++ b/src/main/java/no/novari/kafka/requestreply/RequestTemplateFactory.java
@@ -29,7 +29,7 @@ public class RequestTemplateFactory {
         ConsumerFactoryService consumerFactoryService,
         TopicNameService topicNameService,
         ObjectProvider<ObservationRegistry> observationRegistry,
-        @Value("${fint.kafka.tracing.enabled:false}") boolean tracingEnabled
+        @Value("${novari.kafka.tracing.enabled:false}") boolean tracingEnabled
     ) {
         this.producerFactory = producerFactory;
         this.consumerFactoryService = consumerFactoryService;

--- a/src/test/java/no/novari/kafka/producing/TemplateFactoryTest.java
+++ b/src/test/java/no/novari/kafka/producing/TemplateFactoryTest.java
@@ -1,0 +1,46 @@
+package no.novari.kafka.producing;
+
+import io.micrometer.observation.ObservationRegistry;
+import no.novari.kafka.health.ProducerFailureTracker;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TemplateFactoryTest {
+
+    private final ProducerFactory producerFactory = mock(ProducerFactory.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<ProducerFailureTracker> producerFailureTracker = mock(ObjectProvider.class);
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<ObservationRegistry> observationRegistry = mock(ObjectProvider.class);
+
+    @Test
+    void doesNotQueryObservationRegistryWhenTracingIsDisabled() {
+        when(producerFactory.createFactory(any())).thenReturn(mock(org.springframework.kafka.core.ProducerFactory.class));
+
+        TemplateFactory templateFactory =
+            new TemplateFactory(producerFactory, producerFailureTracker, observationRegistry, false);
+        templateFactory.createTemplate(String.class);
+
+        verify(observationRegistry, never()).ifAvailable(any());
+    }
+
+    @Test
+    void queriesObservationRegistryWhenTracingIsEnabled() {
+        when(producerFactory.createFactory(any())).thenReturn(mock(org.springframework.kafka.core.ProducerFactory.class));
+
+        TemplateFactory templateFactory =
+            new TemplateFactory(producerFactory, producerFailureTracker, observationRegistry, true);
+        templateFactory.createTemplate(String.class);
+
+        verify(observationRegistry).ifAvailable(any());
+    }
+
+}

--- a/src/test/java/no/novari/kafka/tracing/TracingDisabledIntegrationTest.java
+++ b/src/test/java/no/novari/kafka/tracing/TracingDisabledIntegrationTest.java
@@ -1,0 +1,268 @@
+package no.novari.kafka.tracing;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import no.novari.kafka.consuming.ListenerConfiguration;
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService;
+import no.novari.kafka.producing.ParameterizedProducerRecord;
+import no.novari.kafka.producing.ParameterizedTemplate;
+import no.novari.kafka.producing.ParameterizedTemplateFactory;
+import no.novari.kafka.requestreply.ReplyProducerRecord;
+import no.novari.kafka.requestreply.RequestListenerConfiguration;
+import no.novari.kafka.requestreply.RequestListenerContainerFactory;
+import no.novari.kafka.requestreply.RequestProducerRecord;
+import no.novari.kafka.requestreply.RequestTemplate;
+import no.novari.kafka.requestreply.RequestTemplateFactory;
+import no.novari.kafka.requestreply.topic.name.ReplyTopicNameParameters;
+import no.novari.kafka.requestreply.topic.name.RequestTopicNameParameters;
+import no.novari.kafka.topic.name.EventTopicNameParameters;
+import no.novari.kafka.topic.name.TopicNamePrefixParameters;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Beviser at et {@code ObservationRegistry}-bean alene ikke er nok til å slå på Kafka-sporing -
+ * {@code fint.kafka.tracing.enabled=true} må også settes eksplisitt. Uten denne testen ville
+ * en eksisterende bruker av biblioteket (som allerede har actuator + micrometer-tracing på
+ * classpath) fått endret oppførsel ved en versjonsoppgradering.
+ */
+@SpringBootTest(properties = {
+    "management.tracing.sampling.probability=1.0",
+    "spring.kafka.consumer.auto-offset-reset=earliest"
+})
+@EmbeddedKafka(partitions = 1, kraft = true)
+@AutoConfigureObservability
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class TracingDisabledIntegrationTest {
+
+    private static final String TRACEPARENT = "traceparent";
+
+    private final ParameterizedTemplateFactory parameterizedTemplateFactory;
+    private final ParameterizedListenerContainerFactoryService listenerContainerFactoryService;
+    private final RequestTemplateFactory requestTemplateFactory;
+    private final RequestListenerContainerFactory requestListenerContainerFactory;
+    private final InMemorySpanExporter spanExporter;
+
+    TracingDisabledIntegrationTest(
+        @Autowired ParameterizedTemplateFactory parameterizedTemplateFactory,
+        @Autowired ParameterizedListenerContainerFactoryService listenerContainerFactoryService,
+        @Autowired RequestTemplateFactory requestTemplateFactory,
+        @Autowired RequestListenerContainerFactory requestListenerContainerFactory,
+        @Autowired InMemorySpanExporter spanExporter
+    ) {
+        this.parameterizedTemplateFactory = parameterizedTemplateFactory;
+        this.listenerContainerFactoryService = listenerContainerFactoryService;
+        this.requestTemplateFactory = requestTemplateFactory;
+        this.requestListenerContainerFactory = requestListenerContainerFactory;
+        this.spanExporter = spanExporter;
+    }
+
+    @TestConfiguration
+    static class SpanCaptureConfiguration {
+
+        @Bean
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+
+        @Bean
+        SpanProcessor inMemorySpanProcessor(InMemorySpanExporter exporter) {
+            return SimpleSpanProcessor.create(exporter);
+        }
+    }
+
+    @Setter
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    static class TestObject {
+        private Integer integer;
+        private String string;
+    }
+
+    @BeforeEach
+    void resetSpans() {
+        spanExporter.reset();
+    }
+
+    private EventTopicNameParameters topic(String eventName) {
+        return EventTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(
+                TopicNamePrefixParameters
+                    .stepBuilder()
+                    .orgId("test-org-id")
+                    .domainContext("test-domain-context")
+                    .build()
+            )
+            .eventName(eventName)
+            .build();
+    }
+
+    private ConsumerRecord<String, TestObject> produceAndConsume(String eventName) throws InterruptedException {
+        EventTopicNameParameters topicNameParameters = topic(eventName);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<ConsumerRecord<String, TestObject>> consumed = new ArrayList<>();
+
+        ConcurrentMessageListenerContainer<String, TestObject> container =
+            listenerContainerFactoryService
+                .createRecordListenerContainerFactory(
+                    TestObject.class,
+                    consumerRecord -> {
+                        consumed.add(consumerRecord);
+                        latch.countDown();
+                    },
+                    ListenerConfiguration
+                        .stepBuilder()
+                        .groupIdApplicationDefault()
+                        .maxPollRecordsKafkaDefault()
+                        .maxPollIntervalKafkaDefault()
+                        .continueFromPreviousOffsetOnAssignment()
+                        .build(),
+                    null
+                )
+                .createContainer(topicNameParameters);
+        container.start();
+
+        ParameterizedTemplate<TestObject> template =
+            parameterizedTemplateFactory.createTemplate(TestObject.class);
+        template.send(
+            ParameterizedProducerRecord
+                .<TestObject>builder()
+                .topicNameParameters(topicNameParameters)
+                .key("test-key")
+                .value(new TestObject(1, "disabled"))
+                .build()
+        );
+
+        assertThat(latch.await(20, TimeUnit.SECONDS)).isTrue();
+        container.stop();
+        return consumed.getFirst();
+    }
+
+    @Test
+    void producerDoesNotAddTraceparentHeaderByDefault() throws InterruptedException {
+        ConsumerRecord<String, TestObject> record = produceAndConsume("no-traceparent-header");
+
+        assertThat(record.headers().lastHeader(TRACEPARENT))
+            .as("uten fint.kafka.tracing.enabled skal produsenten ikke legge på traceparent")
+            .isNull();
+    }
+
+    @Test
+    void noKafkaSpansAreProducedByDefaultEvenWithObservationRegistryBeanPresent() throws InterruptedException {
+        produceAndConsume("no-kafka-spans");
+        Thread.sleep(500);
+
+        boolean hasKafkaSpan = spanExporter.getFinishedSpanItems().stream()
+            .anyMatch(span -> span.getKind().name().equals("PRODUCER") || span.getKind().name().equals("CONSUMER"));
+
+        assertThat(hasKafkaSpan)
+            .as("tilstedeværelsen av et ObservationRegistry-bean alene skal ikke være nok til å slå på sporing")
+            .isFalse();
+    }
+
+    @Test
+    void requestReplyStillWorksFunctionallyWhenTracingIsDisabled() {
+        var prefix = TopicNamePrefixParameters
+            .stepBuilder()
+            .orgId("test-org-id")
+            .domainContext("test-domain-context")
+            .build();
+
+        RequestTopicNameParameters requestTopic = RequestTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(prefix)
+            .resourceName("disabled-resource")
+            .parameterName("disabled-parameter")
+            .build();
+
+        ReplyTopicNameParameters replyTopic = ReplyTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(prefix)
+            .applicationId("test-application-id")
+            .resourceName("disabled-resource")
+            .build();
+
+        var listenerConfiguration = ListenerConfiguration
+            .stepBuilder()
+            .groupIdApplicationDefault()
+            .maxPollRecordsKafkaDefault()
+            .maxPollIntervalKafkaDefault()
+            .continueFromPreviousOffsetOnAssignment()
+            .build();
+
+        RequestTemplate<Integer, TestObject> requestTemplate = requestTemplateFactory.createTemplate(
+            replyTopic,
+            Integer.class,
+            TestObject.class,
+            Duration.ofSeconds(30),
+            listenerConfiguration
+        );
+
+        List<String> traceparentSeenByServer = new ArrayList<>();
+        var requestListenerContainer = requestListenerContainerFactory
+            .createRecordConsumerFactory(
+                Integer.class,
+                TestObject.class,
+                consumerRecord -> {
+                    var header = consumerRecord.headers().lastHeader(TRACEPARENT);
+                    traceparentSeenByServer.add(
+                        header == null ? null : new String(header.value(), StandardCharsets.UTF_8)
+                    );
+                    return new ReplyProducerRecord<>(new TestObject(2, "reply"));
+                },
+                RequestListenerConfiguration
+                    .stepBuilder(Integer.class)
+                    .maxPollRecordsKafkaDefault()
+                    .maxPollIntervalKafkaDefault()
+                    .build(),
+                null
+            )
+            .createContainer(requestTopic);
+        requestListenerContainer.start();
+
+        var reply = requestTemplate.requestAndReceive(
+            RequestProducerRecord
+                .<Integer>builder()
+                .topicNameParameters(requestTopic)
+                .value(1)
+                .build()
+        );
+
+        requestListenerContainer.stop();
+
+        assertThat(reply)
+            .as("request/reply skal fungere funksjonelt uavhengig av om sporing er aktivert")
+            .isNotNull();
+        assertThat(traceparentSeenByServer)
+            .as("uten fint.kafka.tracing.enabled skal ikke traceparent følge med forespørselen")
+            .containsOnly((String) null);
+    }
+
+}

--- a/src/test/java/no/novari/kafka/tracing/TracingDisabledIntegrationTest.java
+++ b/src/test/java/no/novari/kafka/tracing/TracingDisabledIntegrationTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Beviser at et {@code ObservationRegistry}-bean alene ikke er nok til å slå på Kafka-sporing -
- * {@code fint.kafka.tracing.enabled=true} må også settes eksplisitt. Uten denne testen ville
+ * {@code novari.kafka.tracing.enabled=true} må også settes eksplisitt. Uten denne testen ville
  * en eksisterende bruker av biblioteket (som allerede har actuator + micrometer-tracing på
  * classpath) fått endret oppførsel ved en versjonsoppgradering.
  */
@@ -170,7 +170,7 @@ class TracingDisabledIntegrationTest {
         ConsumerRecord<String, TestObject> record = produceAndConsume("no-traceparent-header");
 
         assertThat(record.headers().lastHeader(TRACEPARENT))
-            .as("uten fint.kafka.tracing.enabled skal produsenten ikke legge på traceparent")
+            .as("uten novari.kafka.tracing.enabled skal produsenten ikke legge på traceparent")
             .isNull();
     }
 
@@ -261,7 +261,7 @@ class TracingDisabledIntegrationTest {
             .as("request/reply skal fungere funksjonelt uavhengig av om sporing er aktivert")
             .isNotNull();
         assertThat(traceparentSeenByServer)
-            .as("uten fint.kafka.tracing.enabled skal ikke traceparent følge med forespørselen")
+            .as("uten novari.kafka.tracing.enabled skal ikke traceparent følge med forespørselen")
             .containsOnly((String) null);
     }
 

--- a/src/test/java/no/novari/kafka/tracing/TracingEnabledIntegrationTest.java
+++ b/src/test/java/no/novari/kafka/tracing/TracingEnabledIntegrationTest.java
@@ -48,12 +48,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Verifiserer at Spring Kafkas observasjonsstøtte propagerer W3C trace-kontekst gjennom det
  * programmatiske produsent-, konsument- og request/reply-oppsettet i biblioteket når
- * {@code fint.kafka.tracing.enabled=true}.
+ * {@code novari.kafka.tracing.enabled=true}.
  */
 @SpringBootTest(properties = {
     "management.tracing.sampling.probability=1.0",
     "spring.kafka.consumer.auto-offset-reset=earliest",
-    "fint.kafka.tracing.enabled=true"
+    "novari.kafka.tracing.enabled=true"
 })
 @EmbeddedKafka(partitions = 1, kraft = true)
 @AutoConfigureObservability

--- a/src/test/java/no/novari/kafka/tracing/TracingEnabledIntegrationTest.java
+++ b/src/test/java/no/novari/kafka/tracing/TracingEnabledIntegrationTest.java
@@ -1,0 +1,370 @@
+package no.novari.kafka.tracing;
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import no.novari.kafka.consuming.ListenerConfiguration;
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService;
+import no.novari.kafka.producing.ParameterizedProducerRecord;
+import no.novari.kafka.producing.ParameterizedTemplate;
+import no.novari.kafka.producing.ParameterizedTemplateFactory;
+import no.novari.kafka.requestreply.ReplyProducerRecord;
+import no.novari.kafka.requestreply.RequestListenerConfiguration;
+import no.novari.kafka.requestreply.RequestListenerContainerFactory;
+import no.novari.kafka.requestreply.RequestProducerRecord;
+import no.novari.kafka.requestreply.RequestTemplate;
+import no.novari.kafka.requestreply.RequestTemplateFactory;
+import no.novari.kafka.requestreply.topic.name.ReplyTopicNameParameters;
+import no.novari.kafka.requestreply.topic.name.RequestTopicNameParameters;
+import no.novari.kafka.topic.name.EventTopicNameParameters;
+import no.novari.kafka.topic.name.TopicNamePrefixParameters;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifiserer at Spring Kafkas observasjonsstøtte propagerer W3C trace-kontekst gjennom det
+ * programmatiske produsent-, konsument- og request/reply-oppsettet i biblioteket når
+ * {@code fint.kafka.tracing.enabled=true}.
+ */
+@SpringBootTest(properties = {
+    "management.tracing.sampling.probability=1.0",
+    "spring.kafka.consumer.auto-offset-reset=earliest",
+    "fint.kafka.tracing.enabled=true"
+})
+@EmbeddedKafka(partitions = 1, kraft = true)
+@AutoConfigureObservability
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class TracingEnabledIntegrationTest {
+
+    private static final String TRACEPARENT = "traceparent";
+
+    private final ParameterizedTemplateFactory parameterizedTemplateFactory;
+    private final ParameterizedListenerContainerFactoryService listenerContainerFactoryService;
+    private final RequestTemplateFactory requestTemplateFactory;
+    private final RequestListenerContainerFactory requestListenerContainerFactory;
+    private final InMemorySpanExporter spanExporter;
+
+    TracingEnabledIntegrationTest(
+        @Autowired ParameterizedTemplateFactory parameterizedTemplateFactory,
+        @Autowired ParameterizedListenerContainerFactoryService listenerContainerFactoryService,
+        @Autowired RequestTemplateFactory requestTemplateFactory,
+        @Autowired RequestListenerContainerFactory requestListenerContainerFactory,
+        @Autowired InMemorySpanExporter spanExporter
+    ) {
+        this.parameterizedTemplateFactory = parameterizedTemplateFactory;
+        this.listenerContainerFactoryService = listenerContainerFactoryService;
+        this.requestTemplateFactory = requestTemplateFactory;
+        this.requestListenerContainerFactory = requestListenerContainerFactory;
+        this.spanExporter = spanExporter;
+    }
+
+    @TestConfiguration
+    static class SpanCaptureConfiguration {
+
+        @Bean
+        InMemorySpanExporter inMemorySpanExporter() {
+            return InMemorySpanExporter.create();
+        }
+
+        @Bean
+        SpanProcessor inMemorySpanProcessor(InMemorySpanExporter exporter) {
+            return SimpleSpanProcessor.create(exporter);
+        }
+    }
+
+    @Setter
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    static class TestObject {
+        private Integer integer;
+        private String string;
+    }
+
+    @BeforeEach
+    void resetSpans() {
+        spanExporter.reset();
+    }
+
+    private EventTopicNameParameters topic(String eventName) {
+        return EventTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(
+                TopicNamePrefixParameters
+                    .stepBuilder()
+                    .orgId("test-org-id")
+                    .domainContext("test-domain-context")
+                    .build()
+            )
+            .eventName(eventName)
+            .build();
+    }
+
+    private ConsumerRecord<String, TestObject> produceAndConsume(String eventName) throws InterruptedException {
+        EventTopicNameParameters topicNameParameters = topic(eventName);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<ConsumerRecord<String, TestObject>> consumed = new ArrayList<>();
+
+        ConcurrentMessageListenerContainer<String, TestObject> container =
+            listenerContainerFactoryService
+                .createRecordListenerContainerFactory(
+                    TestObject.class,
+                    consumerRecord -> {
+                        consumed.add(consumerRecord);
+                        latch.countDown();
+                    },
+                    ListenerConfiguration
+                        .stepBuilder()
+                        .groupIdApplicationDefault()
+                        .maxPollRecordsKafkaDefault()
+                        .maxPollIntervalKafkaDefault()
+                        .continueFromPreviousOffsetOnAssignment()
+                        .build(),
+                    null
+                )
+                .createContainer(topicNameParameters);
+        container.start();
+
+        ParameterizedTemplate<TestObject> template =
+            parameterizedTemplateFactory.createTemplate(TestObject.class);
+        template.send(
+            ParameterizedProducerRecord
+                .<TestObject>builder()
+                .topicNameParameters(topicNameParameters)
+                .key("test-key")
+                .value(new TestObject(1, "enabled"))
+                .build()
+        );
+
+        assertThat(latch.await(20, TimeUnit.SECONDS)).isTrue();
+        container.stop();
+        return consumed.getFirst();
+    }
+
+    private List<SpanData> awaitSpans(int minCount) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            if (spanExporter.getFinishedSpanItems().size() >= minCount) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        Thread.sleep(200);
+        return spanExporter.getFinishedSpanItems();
+    }
+
+    @Test
+    void producerAddsTraceparentHeaderToMessage() throws InterruptedException {
+        ConsumerRecord<String, TestObject> record = produceAndConsume("traceparent-header");
+
+        var traceparent = record.headers().lastHeader(TRACEPARENT);
+        assertThat(traceparent)
+            .as("produsenten skal legge W3C traceparent-header på meldingen når sporing er aktivert")
+            .isNotNull();
+        assertThat(new String(traceparent.value(), StandardCharsets.UTF_8))
+            .matches("00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}");
+    }
+
+    @Test
+    void consumerSpanIsChildOfProducerSpan() throws InterruptedException {
+        ConsumerRecord<String, TestObject> record = produceAndConsume("parent-child-span");
+
+        String traceIdFromHeader = new String(
+            record.headers().lastHeader(TRACEPARENT).value(),
+            StandardCharsets.UTF_8
+        ).split("-")[1];
+
+        List<SpanData> spans = awaitSpans(2).stream()
+            .filter(span -> span.getName().contains("parent-child-span"))
+            .toList();
+
+        assertThat(spans)
+            .as("skal ha både produsent- og konsument-span")
+            .hasSizeGreaterThanOrEqualTo(2);
+        assertThat(spans)
+            .as("alle spans skal ha samme traceId som headeren på meldingen")
+            .allSatisfy(span -> assertThat(span.getTraceId()).isEqualTo(traceIdFromHeader));
+
+        SpanData producerSpan = spans.stream()
+            .filter(span -> span.getKind().name().equals("PRODUCER"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("fant ikke produsent-span"));
+        SpanData consumerSpan = spans.stream()
+            .filter(span -> span.getKind().name().equals("CONSUMER"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("fant ikke konsument-span"));
+
+        assertThat(consumerSpan.getParentSpanId())
+            .as("konsument-spannet skal ha produsent-spannet som forelder")
+            .isEqualTo(producerSpan.getSpanId());
+    }
+
+    @Test
+    void requestReplyStaysInOneTraceAcrossProducerConsumerAndReply() throws InterruptedException {
+        var prefix = TopicNamePrefixParameters
+            .stepBuilder()
+            .orgId("test-org-id")
+            .domainContext("test-domain-context")
+            .build();
+
+        RequestTopicNameParameters requestTopic = RequestTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(prefix)
+            .resourceName("enabled-resource")
+            .parameterName("enabled-parameter")
+            .build();
+
+        ReplyTopicNameParameters replyTopic = ReplyTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(prefix)
+            .applicationId("test-application-id")
+            .resourceName("enabled-resource")
+            .build();
+
+        var listenerConfiguration = ListenerConfiguration
+            .stepBuilder()
+            .groupIdApplicationDefault()
+            .maxPollRecordsKafkaDefault()
+            .maxPollIntervalKafkaDefault()
+            .continueFromPreviousOffsetOnAssignment()
+            .build();
+
+        RequestTemplate<Integer, TestObject> requestTemplate = requestTemplateFactory.createTemplate(
+            replyTopic,
+            Integer.class,
+            TestObject.class,
+            Duration.ofSeconds(30),
+            listenerConfiguration
+        );
+
+        List<String> traceparentSeenByServer = new ArrayList<>();
+        var requestListenerContainer = requestListenerContainerFactory
+            .createRecordConsumerFactory(
+                Integer.class,
+                TestObject.class,
+                consumerRecord -> {
+                    var header = consumerRecord.headers().lastHeader(TRACEPARENT);
+                    traceparentSeenByServer.add(
+                        header == null ? null : new String(header.value(), StandardCharsets.UTF_8)
+                    );
+                    return new ReplyProducerRecord<>(new TestObject(2, "reply"));
+                },
+                RequestListenerConfiguration
+                    .stepBuilder(Integer.class)
+                    .maxPollRecordsKafkaDefault()
+                    .maxPollIntervalKafkaDefault()
+                    .build(),
+                null
+            )
+            .createContainer(requestTopic);
+        requestListenerContainer.start();
+
+        var reply = requestTemplate.requestAndReceive(
+            RequestProducerRecord
+                .<Integer>builder()
+                .topicNameParameters(requestTopic)
+                .value(1)
+                .build()
+        );
+
+        List<SpanData> spans = awaitSpans(3);
+        requestListenerContainer.stop();
+
+        assertThat(reply).isNotNull();
+        assertThat(traceparentSeenByServer)
+            .as("forespørselen skal bære traceparent til den som svarer")
+            .isNotEmpty()
+            .doesNotContainNull();
+        assertThat(spans.stream().map(SpanData::getTraceId).distinct())
+            .as("hele request/reply-kallet skal ligge i ett spor")
+            .hasSize(1);
+    }
+
+    @Test
+    void batchListenerProducesNoConsumerSpan() throws InterruptedException {
+        // Kjent begrensning i Spring Kafkas egen observasjonsstøtte - batch-lyttere gir aldri
+        // consumer-span, uavhengig av dette biblioteket.
+        var topicNameParameters = topic("batch-listener");
+        CountDownLatch latch = new CountDownLatch(1);
+        List<ConsumerRecord<String, TestObject>> consumed = new ArrayList<>();
+
+        var container = listenerContainerFactoryService
+            .createBatchListenerContainerFactory(
+                TestObject.class,
+                records -> {
+                    consumed.addAll(records);
+                    latch.countDown();
+                },
+                ListenerConfiguration
+                    .stepBuilder()
+                    .groupIdApplicationDefault()
+                    .maxPollRecordsKafkaDefault()
+                    .maxPollIntervalKafkaDefault()
+                    .continueFromPreviousOffsetOnAssignment()
+                    .build(),
+                null
+            )
+            .createContainer(topicNameParameters);
+        container.start();
+
+        parameterizedTemplateFactory.createTemplate(TestObject.class).send(
+            ParameterizedProducerRecord
+                .<TestObject>builder()
+                .topicNameParameters(topicNameParameters)
+                .key("test-key")
+                .value(new TestObject(1, "batch"))
+                .build()
+        );
+
+        assertThat(latch.await(20, TimeUnit.SECONDS)).isTrue();
+        Thread.sleep(1000);
+        container.stop();
+
+        ConsumerRecord<String, TestObject> record = consumed.getFirst();
+        assertThat(record.headers().lastHeader(TRACEPARENT))
+            .as("produsentsiden instrumenteres uavhengig av mottakertype")
+            .isNotNull();
+
+        List<SpanData> batchSpans = spanExporter.getFinishedSpanItems().stream()
+            .filter(span -> span.getName().contains("batch-listener"))
+            .toList();
+        long producerSpans = batchSpans.stream()
+            .filter(span -> span.getKind().name().equals("PRODUCER"))
+            .count();
+        long consumerSpans = batchSpans.stream()
+            .filter(span -> span.getKind().name().equals("CONSUMER"))
+            .count();
+
+        assertThat(producerSpans)
+            .as("produsentsiden instrumenteres uavhengig av mottakertype")
+            .isGreaterThanOrEqualTo(1);
+        assertThat(consumerSpans)
+            .as("dokumenterer at batch-lyttere ikke gir consumer-span")
+            .isZero();
+    }
+
+}


### PR DESCRIPTION
## Sammendrag

- Legger til en av-som-standard bryter (`novari.kafka.tracing.enabled`) som slår på Spring Kafkas innebygde observasjonsstøtte for `KafkaTemplate`, `ReplyingKafkaTemplate` og lytter-containerne i `TemplateFactory`, `RequestTemplateFactory` og `ListenerContainerFactoryService`
- Bryteren gater selve `ifAvailable`-kallet mot `ObservationRegistry`, ikke bare injeksjonen - eksisterende brukere med et `ObservationRegistry`-bean fra før (actuator + micrometer-tracing) får ikke endret oppførsel ved en versjonsoppgradering
- To nye integrasjonstester (`TracingDisabledIntegrationTest`, `TracingEnabledIntegrationTest`) og en lett enhetstest (`TemplateFactoryTest`) som verifiserer gatingen
- Ny README-seksjon "Sporing (distribuert tracing)"

Av-som-standard er et biblioteksvalg for å ikke endre oppførsel bak ryggen på eksisterende brukere ved oppgradering — applikasjoner bør sette den til `true` fra start.

Del av OpenTelemetry-tracing-epicen (FFS-2196).